### PR TITLE
Fixes cookie expiration

### DIFF
--- a/lib/xpr-express.js
+++ b/lib/xpr-express.js
@@ -277,7 +277,7 @@ XprmntlExpress.prototype.defaultReadExps = function(req, res) {
 XprmntlExpress.prototype.defaultSaveExps = function(id, config, res) {
   var serial = this.serializeExps(id, config);
   var expiration = new Date();
-  expiration.setYear(expiration.getYear() + 1);
+  expiration.setYear(expiration.getFullYear() + 1);
 
   res.cookie(this.cookieName, serial, { expires: expiration });
 };


### PR DESCRIPTION
`getYear()` is depricated, replace with `getFullYear()`.
